### PR TITLE
fix: include ros_msgs in package data for non-editable installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dimos_lcm"
-version = "0.1.1"
+version = "0.1.2"
 description = "LCM-Foxglove bridge and message utilities for Dimensional Robotics"
 authors = [
     {name = "Dimensional Team", email = "build@dimensionalOS.com"},
@@ -61,6 +61,6 @@ packages = [
 [tool.setuptools.package-data]
 "dimos_lcm" = [
     "*.py",
-    "generated/python_lcm_msgs/**/*"
+    "generated/python_lcm_msgs/**/*",
+    "sources/ros_msgs/**/*.msg"
 ]
-

--- a/tools/foxglove_bridge/config.py
+++ b/tools/foxglove_bridge/config.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Dimensional Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Configuration constants and settings for the LCM-Foxglove bridge.
 """
@@ -6,17 +20,29 @@ import logging
 import os
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger("lcm_foxglove_bridge")
 
 # Get the directory where this config.py file is located
 _CONFIG_DIR = os.path.dirname(os.path.abspath(__file__))
-# Project root is two levels up from tools/foxglove_bridge/
-_PROJECT_ROOT = os.path.abspath(os.path.join(_CONFIG_DIR, "..", ".."))
+# One level up from foxglove_bridge/ to get to package root (dimos_lcm/ when installed)
+_PACKAGE_ROOT = os.path.dirname(_CONFIG_DIR)
 
-# Directory paths - using paths relative to project root
-ROS_MSGS_DIR = os.path.join(_PROJECT_ROOT, "sources", "ros_msgs")
-LCM_PYTHON_MODULES_PATH = os.path.join(_PROJECT_ROOT, "generated", "python_lcm_msgs", "lcm_msgs")
+# Directory paths - try installed location first, fall back to editable
+ROS_MSGS_DIR = os.path.join(_PACKAGE_ROOT, "sources", "ros_msgs")
+if not os.path.isdir(ROS_MSGS_DIR):
+    # Editable install - project root is two levels up from tools/foxglove_bridge/
+    _PROJECT_ROOT = os.path.dirname(_PACKAGE_ROOT)
+    ROS_MSGS_DIR = os.path.join(_PROJECT_ROOT, "sources", "ros_msgs")
+
+LCM_PYTHON_MODULES_PATH = os.path.join(_PACKAGE_ROOT, "generated", "python_lcm_msgs", "lcm_msgs")
+if not os.path.isdir(LCM_PYTHON_MODULES_PATH):
+    _PROJECT_ROOT = os.path.dirname(_PACKAGE_ROOT)
+    LCM_PYTHON_MODULES_PATH = os.path.join(
+        _PROJECT_ROOT, "generated", "python_lcm_msgs", "lcm_msgs"
+    )
 
 # Thread pool settings
 DEFAULT_THREAD_POOL_SIZE = 8
@@ -35,25 +61,19 @@ HARDCODED_SCHEMAS = {
                     "properties": {
                         "stamp": {
                             "type": "object",
-                            "properties": {
-                                "sec": {"type": "integer"},
-                                "nsec": {"type": "integer"}
-                            }
+                            "properties": {"sec": {"type": "integer"}, "nsec": {"type": "integer"}},
                         },
-                        "frame_id": {"type": "string"}
-                    }
+                        "frame_id": {"type": "string"},
+                    },
                 },
                 "height": {"type": "integer"},
                 "width": {"type": "integer"},
                 "encoding": {"type": "string"},
                 "is_bigendian": {"type": "boolean"},
                 "step": {"type": "integer"},
-                "data": {
-                    "type": "string",
-                    "contentEncoding": "base64"
-                }
-            }
-        }
+                "data": {"type": "string", "contentEncoding": "base64"},
+            },
+        },
     },
     "sensor_msgs.CompressedImage": {
         "foxglove_name": "sensor_msgs/msg/CompressedImage",
@@ -65,21 +85,15 @@ HARDCODED_SCHEMAS = {
                     "properties": {
                         "stamp": {
                             "type": "object",
-                            "properties": {
-                                "sec": {"type": "integer"},
-                                "nsec": {"type": "integer"}
-                            }
+                            "properties": {"sec": {"type": "integer"}, "nsec": {"type": "integer"}},
                         },
-                        "frame_id": {"type": "string"}
-                    }
+                        "frame_id": {"type": "string"},
+                    },
                 },
                 "format": {"type": "string"},
-                "data": {
-                    "type": "string",
-                    "contentEncoding": "base64"
-                }
-            }
-        }
+                "data": {"type": "string", "contentEncoding": "base64"},
+            },
+        },
     },
     "sensor_msgs.JointState": {
         "foxglove_name": "sensor_msgs/msg/JointState",
@@ -91,33 +105,18 @@ HARDCODED_SCHEMAS = {
                     "properties": {
                         "stamp": {
                             "type": "object",
-                            "properties": {
-                                "sec": {"type": "integer"},
-                                "nsec": {"type": "integer"}
-                            }
+                            "properties": {"sec": {"type": "integer"}, "nsec": {"type": "integer"}},
                         },
-                        "frame_id": {"type": "string"}
-                    }
+                        "frame_id": {"type": "string"},
+                    },
                 },
-                "name": {
-                    "type": "array",
-                    "items": {"type": "string"}
-                },
-                "position": {
-                    "type": "array",
-                    "items": {"type": "number"}
-                },
-                "velocity": {
-                    "type": "array",
-                    "items": {"type": "number"}
-                },
-                "effort": {
-                    "type": "array",
-                    "items": {"type": "number"}
-                }
+                "name": {"type": "array", "items": {"type": "string"}},
+                "position": {"type": "array", "items": {"type": "number"}},
+                "velocity": {"type": "array", "items": {"type": "number"}},
+                "effort": {"type": "array", "items": {"type": "number"}},
             },
-            "required": ["header", "name", "position", "velocity", "effort"]
-        }
+            "required": ["header", "name", "position", "velocity", "effort"],
+        },
     },
     "tf2_msgs.TFMessage": {
         "foxglove_name": "tf2_msgs/msg/TFMessage",
@@ -136,11 +135,11 @@ HARDCODED_SCHEMAS = {
                                         "type": "object",
                                         "properties": {
                                             "sec": {"type": "integer"},
-                                            "nsec": {"type": "integer"}
-                                        }
+                                            "nsec": {"type": "integer"},
+                                        },
                                     },
-                                    "frame_id": {"type": "string"}
-                                }
+                                    "frame_id": {"type": "string"},
+                                },
                             },
                             "child_frame_id": {"type": "string"},
                             "transform": {
@@ -151,8 +150,8 @@ HARDCODED_SCHEMAS = {
                                         "properties": {
                                             "x": {"type": "number"},
                                             "y": {"type": "number"},
-                                            "z": {"type": "number"}
-                                        }
+                                            "z": {"type": "number"},
+                                        },
                                     },
                                     "rotation": {
                                         "type": "object",
@@ -160,16 +159,16 @@ HARDCODED_SCHEMAS = {
                                             "x": {"type": "number"},
                                             "y": {"type": "number"},
                                             "z": {"type": "number"},
-                                            "w": {"type": "number"}
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                                            "w": {"type": "number"},
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
                 }
-            }
-        }
+            },
+        },
     },
     "sensor_msgs.PointCloud2": {
         "foxglove_name": "sensor_msgs/msg/PointCloud2",
@@ -181,15 +180,12 @@ HARDCODED_SCHEMAS = {
                     "properties": {
                         "stamp": {
                             "type": "object",
-                            "properties": {
-                                "sec": {"type": "integer"},
-                                "nsec": {"type": "integer"}
-                            },
-                            "required": ["sec", "nsec"]
+                            "properties": {"sec": {"type": "integer"}, "nsec": {"type": "integer"}},
+                            "required": ["sec", "nsec"],
                         },
-                        "frame_id": {"type": "string"}
+                        "frame_id": {"type": "string"},
                     },
-                    "required": ["stamp", "frame_id"]
+                    "required": ["stamp", "frame_id"],
                 },
                 "height": {"type": "integer"},
                 "width": {"type": "integer"},
@@ -203,25 +199,28 @@ HARDCODED_SCHEMAS = {
                             "datatype": {"type": "integer"},
                             "count": {"type": "integer"},
                         },
-                        "required": ["name","offset","datatype","count"]
-                    }
+                        "required": ["name", "offset", "datatype", "count"],
+                    },
                 },
                 "is_bigendian": {"type": "boolean"},
                 "point_step": {"type": "integer"},
                 "row_step": {"type": "integer"},
-                "data": {
-                    "type": "string",
-                    "contentEncoding": "base64"
-                },
-                "is_dense": {"type": "boolean"}
+                "data": {"type": "string", "contentEncoding": "base64"},
+                "is_dense": {"type": "boolean"},
             },
             "required": [
-                "header","height","width","fields",
-                "is_bigendian","point_step","row_step",
-                "data","is_dense"
-            ]
-        }
-    }
+                "header",
+                "height",
+                "width",
+                "fields",
+                "is_bigendian",
+                "point_step",
+                "row_step",
+                "data",
+                "is_dense",
+            ],
+        },
+    },
 }
 
 # Mapping of ROS primitive types to JSON schema types
@@ -242,18 +241,12 @@ TYPE_MAPPING = {
     "byte": {"type": "integer", "minimum": 0, "maximum": 255},
     "time": {
         "type": "object",
-        "properties": {
-            "sec": {"type": "integer"},
-            "nsec": {"type": "integer"}
-        },
-        "required": ["sec", "nsec"]
+        "properties": {"sec": {"type": "integer"}, "nsec": {"type": "integer"}},
+        "required": ["sec", "nsec"],
     },
     "duration": {
         "type": "object",
-        "properties": {
-            "sec": {"type": "integer"},
-            "nsec": {"type": "integer"}
-        },
-        "required": ["sec", "nsec"]
+        "properties": {"sec": {"type": "integer"}, "nsec": {"type": "integer"}},
+        "required": ["sec", "nsec"],
     },
 }


### PR DESCRIPTION
## Summary
- The .msg files in `sources/ros_msgs/` were not being packaged
- This caused `FileNotFoundError` when using the foxglove bridge from a regular pip install (non-editable)
- Fixed path resolution in `config.py` to work for both installed and editable modes
